### PR TITLE
Insert ads every 200 words in articles

### DIFF
--- a/Cornell Sun/Cornell Sun/AppDelegate.swift
+++ b/Cornell Sun/Cornell Sun/AppDelegate.swift
@@ -126,8 +126,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
     }
-    
-    
 
     /**
      Receive a universal link redirect and handle it properly. Uses Handoff.
@@ -151,8 +149,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         return true
     }
-
-
 
     /**
      Handles opening the url separately (eg. opening cornellsun.com in Safari)

--- a/Cornell Sun/Cornell Sun/Extensions/Extensions.swift
+++ b/Cornell Sun/Cornell Sun/Extensions/Extensions.swift
@@ -97,6 +97,11 @@ extension String {
         return ceil(boundingBox.width)
     }
 
+    func getWordCount() -> Int {
+        let stringComponents = components(separatedBy: .whitespacesAndNewlines)
+        return stringComponents.filter { !$0.isEmpty }.count
+    }
+
     /// Converts HTML string to a `NSAttributedString`
     var htmlToAttributedString: NSAttributedString? {
         return try? NSAttributedString(data: Data(utf8), options: [.documentType: NSAttributedString.DocumentType.html, .characterEncoding: String.Encoding.utf8.rawValue], documentAttributes: nil)

--- a/Cornell Sun/Cornell Sun/Sections Section/SectionViewController.swift
+++ b/Cornell Sun/Cornell Sun/Sections Section/SectionViewController.swift
@@ -27,7 +27,7 @@ enum Sections {
 
 class SectionViewController: UIViewController {
     var tableView: UITableView!
-    var sections: [Sections] = [.news(id: 2), .opinion(id: 3),  .sports(id: 4), .arts(id: 5), .science(id: 6), .dining(id: 7), .multimedia(id: 9)]
+    var sections: [Sections] = [.news(id: 2), .opinion(id: 3), .sports(id: 4), .arts(id: 5), .science(id: 6), .dining(id: 7), .multimedia(id: 9)]
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)

--- a/Cornell Sun/Enums.swift
+++ b/Cornell Sun/Enums.swift
@@ -20,6 +20,7 @@ enum ArticleContentType {
     case caption(String)
     case blockquote(String)
     case heading(String)
+    case ad
 }
 
 enum PostType: String, Codable {


### PR DESCRIPTION
- Approximately 2-3 ads per article (1 every 200 or so words)
- Ran `swiftlint autocorrect` to fix some whitespace issues

Example:
<img width="363" alt="image" src="https://user-images.githubusercontent.com/20246620/53994467-63b32100-4100-11e9-9703-718152984657.png">
