### PR TITLE
Closes #112: Fixed View Controller Titles Disappearing After Navigating to Articles

### DIFF
--- a/Cornell Sun/Cornell Sun/Bookmark Section/BookmarkCollectionViewController.swift
+++ b/Cornell Sun/Cornell Sun/Bookmark Section/BookmarkCollectionViewController.swift
@@ -28,7 +28,7 @@ class BookmarkCollectionViewController: ViewController, UIScrollViewDelegate {
     }()
 
     override func viewWillAppear(_ animated: Bool) {
-        title = "Bookmarks"
+        navigationItem.title = "Bookmarks"
         navigationController?.navigationBar.barTintColor = .white
         navigationController?.navigationBar.titleTextAttributes = [
             NSAttributedString.Key.font: UIFont.headerTitle
@@ -44,8 +44,6 @@ class BookmarkCollectionViewController: ViewController, UIScrollViewDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Bookmarks"
-
         view.addSubview(collectionView)
         adapter.collectionView = collectionView
         adapter.collectionView?.backgroundColor = .black5

--- a/Cornell Sun/Cornell Sun/Networking/NetworkingHelpers.swift
+++ b/Cornell Sun/Cornell Sun/Networking/NetworkingHelpers.swift
@@ -91,7 +91,7 @@ func getComments(postID: Int, completion: @escaping CommentsCompletionBlock) {
 func getPostsFromIDs(_ ids: [Int], completion: @escaping ([Int: PostObject], APIErrors?) -> Void) {
     let group = DispatchGroup()
     var postsDict = [Int: PostObject]()
-
+    
     ids.forEach { id in
         group.enter()
         API.request(target: .post(postId: id)) { response in
@@ -107,11 +107,11 @@ func getPostsFromIDs(_ ids: [Int], completion: @escaping ([Int: PostObject], API
                 print(error)
                 return
             }
-
+            
         }
         group.leave()
     }
-
+    
     group.notify(queue: .main) {
         completion(postsDict, nil)
     }
@@ -148,9 +148,9 @@ func getIDFromURL(_ url: URL, completion: @escaping (Int?) -> Void) {
 func prepareInitialPosts(callback: @escaping ([ListDiffable], PostObject?) -> Void) {
     var headlinePost: PostObject?
     var postObjects: [ListDiffable] = []
-
+    
     let group = DispatchGroup()
-
+    
     group.enter()
     API.request(target: .featured) { (response) in
         if let response = response {
@@ -165,11 +165,11 @@ func prepareInitialPosts(callback: @escaping ([ListDiffable], PostObject?) -> Vo
         }
         group.leave()
     }
-
+    
     group.enter()
     API.request(target: .posts(page: 1)) { (response) in
         if let response = response {
-
+            
             do {
                 postObjects = try decoder.decode([PostObject].self, from: response.data)
                 postObjects.insert("adToken" as ListDiffable, at: 7)
@@ -178,10 +178,10 @@ func prepareInitialPosts(callback: @escaping ([ListDiffable], PostObject?) -> Vo
                 return
             }
         }
-
+        
         group.leave()
     }
-
+    
     group.notify(queue: .main) {
         //both network requests are done
         postObjects = postObjects.filter { post in
@@ -197,20 +197,20 @@ func getDeeplinkedPostWithId(_ id: Int, completion: @escaping ([ListDiffable], P
     var posts: [ListDiffable] = []
     var heroPost: PostObject?
     var deeplinkPost: PostObject?
-
+    
     group.enter()
     prepareInitialPosts { (postObjects, headlinePost) in
         posts = postObjects
         heroPost = headlinePost
         group.leave()
     }
-
+    
     group.enter()
     getPostFromID(id) { post in
         deeplinkPost = post
         group.leave()
     }
-
+    
     group.notify(queue: .main) {
         completion(posts, heroPost, deeplinkPost)
     }

--- a/Cornell Sun/Cornell Sun/PhotoGallery/PhotoGallery.swift
+++ b/Cornell Sun/Cornell Sun/PhotoGallery/PhotoGallery.swift
@@ -118,7 +118,9 @@ extension PhotoGallery: UICollectionViewDataSource, UICollectionViewDelegate, UI
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "image-cell", for: indexPath) as? ImageCollectionCell else { return UICollectionViewCell() }
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "image-cell", for: indexPath) as? ImageCollectionCell else {
+            return UICollectionViewCell()
+        }
 
         cell.imageView.kf.setImage(with: attachments[indexPath.item].url, progressBlock: { receivedSize, totalSize in
             let percentage = (CGFloat(receivedSize) / CGFloat(totalSize)) * 100.0
@@ -148,6 +150,6 @@ extension PhotoGallery: UICollectionViewDataSource, UICollectionViewDelegate, UI
 
 extension UIScrollView {
     var currentPage: Int {
-        return Int((self.contentOffset.x + (0.5*self.frame.size.width))/self.frame.width)
+        return Int((self.contentOffset.x + (0.5 * self.frame.size.width)) / self.frame.width)
     }
 }

--- a/Cornell Sun/Cornell Sun/SearchViewController.swift
+++ b/Cornell Sun/Cornell Sun/SearchViewController.swift
@@ -56,7 +56,7 @@ class SearchViewController: UIViewController, UITableViewDelegate {
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        title = "Search"
+        navigationItem.title = "Search"
         if #available(iOS 11, *) {
             navigationItem.searchController = searchController
             navigationItem.hidesSearchBarWhenScrolling = false

--- a/Cornell Sun/Cornell Sun/Sections Section/SectionCollectionViewController.swift
+++ b/Cornell Sun/Cornell Sun/Sections Section/SectionCollectionViewController.swift
@@ -32,6 +32,7 @@ class SectionCollectionViewController: UIViewController, UIScrollViewDelegate {
     var adCount = 1
     var sectionID = 0
     let spinToken = "spinner"
+    var sectionTitle = ""
 
     let collectionView: UICollectionView = {
         let view = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -47,7 +48,7 @@ class SectionCollectionViewController: UIViewController, UIScrollViewDelegate {
     init(with section: Sections, sectionTitle: String) {
         super.init(nibName: nil, bundle: nil)
         sectionSelected = section
-        title = sectionTitle
+        self.sectionTitle = sectionTitle
         navigationController?.navigationBar.titleTextAttributes = [
             NSAttributedString.Key.font: UIFont.headerTitle
         ]
@@ -111,6 +112,7 @@ class SectionCollectionViewController: UIViewController, UIScrollViewDelegate {
         navigationController?.navigationBar.titleTextAttributes = [
             NSAttributedString.Key.font: UIFont.headerTitle
         ]
+        navigationItem.title = sectionTitle
     }
 
     override func didReceiveMemoryWarning() {

--- a/Cornell Sun/Cornell Sun/Sections Section/SectionViewController.swift
+++ b/Cornell Sun/Cornell Sun/Sections Section/SectionViewController.swift
@@ -31,11 +31,11 @@ class SectionViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        title = "Sections"
         navigationController?.navigationBar.barTintColor = .white
         navigationController?.navigationBar.titleTextAttributes = [
             NSAttributedString.Key.font: UIFont.headerTitle
         ]
+        navigationItem.title = "Sections"
     }
 
     override func viewDidLoad() {


### PR DESCRIPTION
The titles for Search, Bookmark, and Sections View Controllers were disappearing after navigating into articles and then clicking the back button in those controllers. Rather than set the title of the View Controller itself, setting the title of the UINavigationItem itself fixed this.