### PR TITLE
Fixed disappearing tab bar title

### DIFF
--- a/Cornell Sun/Cornell Sun/Settings Section/ContactViewController.swift
+++ b/Cornell Sun/Cornell Sun/Settings Section/ContactViewController.swift
@@ -12,7 +12,6 @@ import MessageUI
 class ContactViewController: UIViewController, UITextFieldDelegate, MFMailComposeViewControllerDelegate, UITextViewDelegate {
     
     var prevViewController: UIViewController!
-    var titleCache: String!
     var settingType: SettingType!
     
     var headerLabel: UILabel!
@@ -45,14 +44,11 @@ class ContactViewController: UIViewController, UITextFieldDelegate, MFMailCompos
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        titleCache = prevViewController.title
-        prevViewController.title = "Settings"
         tabBarController?.tabBar.isHidden = true
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        prevViewController.title = titleCache
         tabBarController?.tabBar.isHidden = false
     }
 

--- a/Cornell Sun/Cornell Sun/Settings Section/DisplayViewController.swift
+++ b/Cornell Sun/Cornell Sun/Settings Section/DisplayViewController.swift
@@ -11,7 +11,6 @@ import UIKit
 class DisplayViewController: UIViewController {
     
     var prevViewController: UIViewController!
-    var titleCache: String!
     var type: SettingType!
     
     var headerLabel: UILabel!
@@ -32,8 +31,6 @@ class DisplayViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        titleCache = prevViewController.title
-        prevViewController.title = "Settings"
         tabBarController?.tabBar.isHidden = true
         descriptionTextView.isScrollEnabled = true
         
@@ -46,7 +43,6 @@ class DisplayViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        prevViewController.title = titleCache
         tabBarController?.tabBar.isHidden = false
         tabHidden["hidden"] = false
         NotificationCenter.default.post(name: Notification.Name("hideTabBar"), object: nil, userInfo: tabHidden)

--- a/Cornell Sun/Cornell Sun/Settings Section/NotificationViewController.swift
+++ b/Cornell Sun/Cornell Sun/Settings Section/NotificationViewController.swift
@@ -28,7 +28,6 @@ protocol NotificationsTableViewCellDelegate: class {
 class NotificationViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
     
     var prevViewController: UIViewController!
-    var titleCache: String!
     
     var tableView: UITableView!
     var notifications: [(String, NotificationType)] = []
@@ -39,14 +38,11 @@ class NotificationViewController: UIViewController, UITableViewDataSource, UITab
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        titleCache = prevViewController.title
-        prevViewController.title = "Settings"
         tabBarController?.tabBar.isHidden = true
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        prevViewController.title = titleCache
         tabBarController?.tabBar.isHidden = false
     }
     

--- a/Cornell Sun/Cornell Sun/Settings Section/SubscribeViewController.swift
+++ b/Cornell Sun/Cornell Sun/Settings Section/SubscribeViewController.swift
@@ -11,7 +11,6 @@ import SafariServices
 class SubscribeViewController: UIViewController, UITextFieldDelegate, UIPickerViewDataSource, UIPickerViewDelegate {
 
     var prevViewController: UIViewController!
-    var titleCache: String!
     var pickerList: [String] = ["Cornell Student", "Cornell Alumnus", "Parent", "Cornell staff", "Other"]
 
     var headerLabel: UILabel!
@@ -53,14 +52,11 @@ class SubscribeViewController: UIViewController, UITextFieldDelegate, UIPickerVi
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        titleCache = prevViewController.title
-        prevViewController.title = "Settings"
         tabBarController?.tabBar.isHidden = true
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        prevViewController.title = titleCache
         tabBarController?.tabBar.isHidden = false
     }
 

--- a/Cornell Sun/Cornell Sun/Settings Section/TeamViewController.swift
+++ b/Cornell Sun/Cornell Sun/Settings Section/TeamViewController.swift
@@ -27,7 +27,6 @@ class TeamMember {
 class TeamViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
     
     var prevViewController: UIViewController!
-    var titleCache: String!
     
     var tableView: UITableView!
     var members: [TeamMember] = []
@@ -36,14 +35,11 @@ class TeamViewController: UIViewController, UITableViewDataSource, UITableViewDe
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        titleCache = prevViewController.title
-        prevViewController.title = "Settings"
         tabBarController?.tabBar.isHidden = true
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        prevViewController.title = titleCache
         tabBarController?.tabBar.isHidden = false
     }
     

--- a/Cornell Sun/Cornell Sun/Settings Section/ThemeViewController.swift
+++ b/Cornell Sun/Cornell Sun/Settings Section/ThemeViewController.swift
@@ -15,7 +15,6 @@ enum ThemeType: String {
 class ThemeViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
     var prevViewController: UIViewController!
-    var titleCache: String!
     
     var tableView: UITableView!
     var themes: [(String, ThemeType)] = []
@@ -25,14 +24,11 @@ class ThemeViewController: UIViewController, UITableViewDelegate, UITableViewDat
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        titleCache = prevViewController.title
-        prevViewController.title = "Settings"
         tabBarController?.tabBar.isHidden = true
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        prevViewController.title = titleCache
         tabBarController?.tabBar.isHidden = false
     }
     


### PR DESCRIPTION
The issue was caused by the pushed view controllers attempting to save the parent view controller's title in `viewDidLoad`, and restore it `viewDidDisappear`. It seems that the title was saved as `nil`, and upon restoration it would set the tab bar icon's title to `nil`. Saving the title is not actually necessary at all, so I removed the relevant code from each of the view controllers that can be pushed from the Settings tab.